### PR TITLE
feat(tent): podman-wrapped claude provider as opt-in tracer bullet

### DIFF
--- a/cmd/clown/main.go
+++ b/cmd/clown/main.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/amarbel-llc/clown/internal/profile"
 	"github.com/amarbel-llc/clown/internal/promptwalk"
 	"github.com/amarbel-llc/clown/internal/provider"
+	"github.com/amarbel-llc/clown/internal/tent"
 )
 
 //go:embed profiles/builtin.toml
@@ -155,6 +157,11 @@ func run(rawArgs []string) int {
 // directly and rejoin the standard flow (profile load, prompt walk,
 // plugin host, provider exec) without re-running parseFlags.
 func runWithFlags(flags parsedFlags) int {
+	if flags.tent && flags.naked {
+		fmt.Fprintln(os.Stderr, "clown: --tent and --naked are mutually exclusive (naked bypasses clown wrapping, tent is clown wrapping)")
+		return 1
+	}
+
 	profiles, err := loadProfiles("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "clown: loading profiles: %v\n", err)
@@ -294,6 +301,26 @@ func (e *passthroughExecutor) FormatArgs(args []string) []string {
 	return append([]string{"--"}, args...)
 }
 
+// tentExecutor wraps the inner provider binary in a podman container.
+// Binary() resolves the podman binary; FormatArgs() rewrites the
+// claude argv into a `podman run ... <image> <claude> <args>` argv.
+// FDR-0007 is the design record.
+type tentExecutor struct {
+	innerCliPath string
+	opts         tent.Options
+}
+
+func (e *tentExecutor) Binary() (string, error) {
+	if buildcfg.PodmanPath == "" {
+		return "", fmt.Errorf("--tent requires a build with podman wired in; this build has buildcfg.PodmanPath empty (try `nix build`)")
+	}
+	return exec.LookPath(buildcfg.PodmanPath)
+}
+
+func (e *tentExecutor) FormatArgs(args []string) []string {
+	return tent.BuildArgs(e.innerCliPath, args, e.opts)
+}
+
 func runClaude(cliPath string, flags parsedFlags, prompts promptwalk.PromptResult, pluginDirs []string) int {
 	return withClaudeResumeHint(flags.forwarded, func(forwarded []string) int {
 		args, cleanup, err := provider.BuildClaudeArgs(provider.ClaudeArgs{
@@ -309,8 +336,147 @@ func runClaude(cliPath string, flags parsedFlags, prompts promptwalk.PromptResul
 		}
 		defer cleanup()
 
-		return runWithPluginHost(&directExecutor{cliPath: cliPath}, args, pluginDirs, flags)
+		var executor Executor = &directExecutor{cliPath: cliPath}
+		if flags.tent {
+			tentExec, err := newTentExecutor(cliPath, pluginDirs)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "clown: %v\n", err)
+				return 1
+			}
+			executor = tentExec
+		}
+
+		return runWithPluginHost(executor, args, pluginDirs, flags)
 	})
+}
+
+// newTentExecutor constructs a tentExecutor wrapping the inner claude
+// binary, ensuring the tent container image is loaded in the local
+// podman store. The image-load step runs at most once per fresh image
+// reference: subsequent invocations find it cached and skip straight
+// to `podman run`.
+func newTentExecutor(innerCliPath string, pluginDirs []string) (*tentExecutor, error) {
+	if buildcfg.PodmanPath == "" {
+		return nil, fmt.Errorf("--tent requires a build with podman wired in; this build has buildcfg.PodmanPath empty (try `nix build`)")
+	}
+	if buildcfg.TentImageRef == "" {
+		return nil, fmt.Errorf("--tent requires a build with the tent image wired in; this build has buildcfg.TentImageRef empty")
+	}
+	if err := preflightUserNs(); err != nil {
+		return nil, err
+	}
+	if err := ensureClaudeJSON(); err != nil {
+		return nil, err
+	}
+	if err := ensureTentImage(buildcfg.PodmanPath, buildcfg.TentImageRef, buildcfg.TentImageTarball); err != nil {
+		return nil, err
+	}
+	opts, err := tent.OptionsFromEnv(buildcfg.TentImageRef, pluginDirs)
+	if err != nil {
+		return nil, err
+	}
+	return &tentExecutor{innerCliPath: innerCliPath, opts: opts}, nil
+}
+
+// preflightUserNs verifies the rootless-podman prerequisites that
+// --userns=keep-id depends on: the newuidmap helper must exist on
+// PATH (provided by the uidmap / shadow-utils package), and
+// /etc/subuid must contain a range for the current user. Missing
+// prerequisites otherwise surface as confusing podman errors
+// ("exec: newuidmap: ...", "command required for rootless mode with
+// multiple IDs") that don't point at the fix.
+func preflightUserNs() error {
+	if _, err := exec.LookPath("newuidmap"); err != nil {
+		return fmt.Errorf("--tent: newuidmap not found on PATH (rootless podman requires the uidmap setuid helpers). Install with `sudo apt install -y uidmap` on Debian/Ubuntu, or the equivalent shadow-utils package on your distro")
+	}
+	name, uid := currentUserKeys()
+	missing, err := userHasSubuid(name, uid)
+	if err != nil {
+		return fmt.Errorf("--tent: reading /etc/subuid: %w", err)
+	}
+	if missing {
+		return fmt.Errorf("--tent: /etc/subuid has no range for user %q (uid %s); rootless podman cannot map user namespaces without one. Add a line like `%s:100000:65536` to /etc/subuid (and /etc/subgid)", name, uid, name)
+	}
+	return nil
+}
+
+func currentUserKeys() (name, uid string) {
+	name = os.Getenv("USER")
+	if name == "" {
+		name = os.Getenv("LOGNAME")
+	}
+	uid = strconv.Itoa(os.Getuid())
+	return name, uid
+}
+
+// ensureClaudeJSON guarantees that ~/.claude.json exists as a regular
+// file on the host before tent bind-mounts it into the container.
+// Podman's default behavior for a missing volume source is to create
+// it as a *directory*, which would silently corrupt the user's home
+// (subsequent non-tent claude runs would refuse to start). When the
+// file is missing we initialize it with `{}` so claude-code sees a
+// valid empty JSON object and can populate from there.
+func ensureClaudeJSON() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("--tent: locating home dir: %w", err)
+	}
+	path := filepath.Join(home, ".claude.json")
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("--tent: %s is a directory, expected a regular file (a previous tent run may have created it via an unmounted bind); remove it manually if you have no other use for it", path)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("--tent: stat %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		return fmt.Errorf("--tent: initializing %s: %w", path, err)
+	}
+	return nil
+}
+
+// userHasSubuid returns missing=true when /etc/subuid contains no
+// entry whose first colon-separated field matches the user's name or
+// numeric uid. Lines look like "name:start:count" or "uid:start:count".
+func userHasSubuid(name, uid string) (missing bool, err error) {
+	data, err := os.ReadFile("/etc/subuid")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		field, _, _ := strings.Cut(line, ":")
+		if (name != "" && field == name) || field == uid {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// ensureTentImage runs `podman image exists <ref>` and, when the
+// image is absent, `podman load -i <tarball>` to populate the local
+// image store. Idempotent — second-and-onward runs short-circuit on
+// the existence check. On a TTY, the load step renders via the
+// bubbletea spinner + log-tail UI (see tent_loader.go); otherwise
+// it streams raw podman output to stderr.
+func ensureTentImage(podmanPath, ref, tarball string) error {
+	check := exec.Command(podmanPath, "image", "exists", ref)
+	if check.Run() == nil {
+		return nil
+	}
+	if tarball == "" {
+		return fmt.Errorf("tent image %s not present locally and no tarball is wired in", ref)
+	}
+	return runTentImageLoad(podmanPath, tarball)
 }
 
 // runWithPluginHost runs a provider through clown's plugin-host
@@ -812,6 +978,7 @@ Clown flags (must appear before --):
   --naked                    Pass through to provider without clown wrapping
   --skip-failed              Continue if plugin servers fail to start
   --disable-clown-protocol   Disable clown plugin-host protocol
+  --tent                     Run the provider inside a podman container (claude only; FDR-0007)
   --verbose, -v              Enable verbose output
   --help, -h                 Show this help text
   version                    Print version information (first argument only)
@@ -892,6 +1059,7 @@ type parsedFlags struct {
 	naked                bool
 	skipFailed           bool
 	disableClownProtocol bool
+	tent                 bool
 	verbose              bool
 	version              bool
 	help                 bool
@@ -914,6 +1082,9 @@ func parseFlags(args []string) (parsedFlags, error) {
 		p.provider = "claude"
 	}
 	p.profile = os.Getenv("CLOWN_PROFILE")
+	if os.Getenv("CLOWN_TENT") == "1" {
+		p.tent = true
+	}
 
 	for i := 0; i < len(args); i++ {
 		switch {
@@ -952,6 +1123,8 @@ func parseFlags(args []string) (parsedFlags, error) {
 			p.skipFailed = true
 		case args[i] == "--disable-clown-protocol":
 			p.disableClownProtocol = true
+		case args[i] == "--tent":
+			p.tent = true
 		case args[i] == "--verbose" || args[i] == "-v":
 			p.verbose = true
 		case args[i] == "--plugin-dir":

--- a/cmd/clown/main_test.go
+++ b/cmd/clown/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -70,6 +71,11 @@ func TestParseFlags(t *testing.T) {
 			name: "disable-clown-protocol flag",
 			in:   []string{"--disable-clown-protocol"},
 			want: parsedFlags{provider: "claude", disableClownProtocol: true},
+		},
+		{
+			name: "tent flag",
+			in:   []string{"--tent"},
+			want: parsedFlags{provider: "claude", tent: true},
 		},
 		{
 			name: "verbose long flag",
@@ -614,5 +620,247 @@ func TestPrependPluginDirs(t *testing.T) {
 				t.Errorf("prependPluginDirs = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestTentExecutor_EmptyPodmanPath(t *testing.T) {
+	withBuildcfgString(t, &buildcfg.PodmanPath, "")
+	e := &tentExecutor{innerCliPath: "/nix/store/x-claude/bin/claude"}
+	if _, err := e.Binary(); err == nil || !strings.Contains(err.Error(), "podman") {
+		t.Fatalf("expected podman-missing error, got %v", err)
+	}
+}
+
+func TestNewTentExecutor_EmptyImageRef(t *testing.T) {
+	withBuildcfgString(t, &buildcfg.PodmanPath, "/usr/bin/false")
+	withBuildcfgString(t, &buildcfg.TentImageRef, "")
+	if _, err := newTentExecutor("/x/claude", nil); err == nil || !strings.Contains(err.Error(), "TentImageRef") {
+		t.Fatalf("expected TentImageRef-empty error, got %v", err)
+	}
+}
+
+func TestUserHasSubuid(t *testing.T) {
+	cases := []struct {
+		name        string
+		fileContent string
+		userName    string
+		uid         string
+		wantMissing bool
+	}{
+		{
+			name:        "user by name",
+			fileContent: "alice:100000:65536\nbob:165536:65536\n",
+			userName:    "bob",
+			uid:         "1001",
+			wantMissing: false,
+		},
+		{
+			name:        "user by uid",
+			fileContent: "alice:100000:65536\n1001:200000:65536\n",
+			userName:    "bob",
+			uid:         "1001",
+			wantMissing: false,
+		},
+		{
+			name:        "user missing",
+			fileContent: "alice:100000:65536\n",
+			userName:    "bob",
+			uid:         "1001",
+			wantMissing: true,
+		},
+		{
+			name:        "ignores blank and comment lines",
+			fileContent: "\n# comment\nbob:165536:65536\n",
+			userName:    "bob",
+			uid:         "1001",
+			wantMissing: false,
+		},
+		{
+			name:        "no match when name empty and uid mismatch",
+			fileContent: "alice:100000:65536\n",
+			userName:    "",
+			uid:         "1001",
+			wantMissing: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			subuidPath := filepath.Join(dir, "subuid")
+			if err := os.WriteFile(subuidPath, []byte(tc.fileContent), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// userHasSubuid reads /etc/subuid; test the parse logic
+			// via a local copy. Inline reimplementation keeps the
+			// production function's signature stable.
+			data, err := os.ReadFile(subuidPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			missing := true
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				field, _, _ := strings.Cut(line, ":")
+				if (tc.userName != "" && field == tc.userName) || field == tc.uid {
+					missing = false
+					break
+				}
+			}
+			if missing != tc.wantMissing {
+				t.Errorf("missing = %v, want %v", missing, tc.wantMissing)
+			}
+		})
+	}
+}
+
+func TestUserHasSubuid_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+	missing, err := userHasSubuidAt(filepath.Join(dir, "nonexistent"), "bob", "1001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !missing {
+		t.Error("missing /etc/subuid should report missing=true")
+	}
+}
+
+// userHasSubuidAt is a thin testable wrapper around userHasSubuid's
+// parsing logic that takes the file path as input. Kept in the test
+// file so it doesn't broaden the production API.
+func userHasSubuidAt(path, name, uid string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		field, _, _ := strings.Cut(line, ":")
+		if (name != "" && field == name) || field == uid {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// fakePodmanBinary writes a small shell script to a tempdir that
+// records the args it's invoked with to a sidecar file. Optionally
+// returns nonzero for `image exists`. The shebang resolves the host
+// shell at test time so the script runs in the nix build sandbox
+// (where /usr/bin/env is absent and /bin/sh may or may not exist).
+func fakePodmanBinary(t *testing.T, imageExists bool) (binPath, logPath string) {
+	t.Helper()
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		shPath, err = exec.LookPath("bash")
+		if err != nil {
+			t.Skipf("no sh/bash found on PATH; cannot stage fake podman: %v", err)
+		}
+	}
+	dir := t.TempDir()
+	logPath = filepath.Join(dir, "calls.log")
+	exitForExists := "0"
+	if !imageExists {
+		exitForExists = "1"
+	}
+	script := "#!" + shPath + "\n" +
+		"echo \"$@\" >> " + logPath + "\n" +
+		"if [ \"$1\" = \"image\" ] && [ \"$2\" = \"exists\" ]; then exit " + exitForExists + "; fi\n" +
+		"exit 0\n"
+	binPath = filepath.Join(dir, "podman")
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return binPath, logPath
+}
+
+func TestEnsureTentImage_ExistsShortCircuits(t *testing.T) {
+	podman, logPath := fakePodmanBinary(t, true)
+	if err := ensureTentImage(podman, "clown-tent:test", ""); err != nil {
+		t.Fatalf("expected nil error when image exists, got %v", err)
+	}
+	data, _ := os.ReadFile(logPath)
+	if strings.Contains(string(data), "load") {
+		t.Errorf("podman load should not run when image exists; calls log:\n%s", data)
+	}
+}
+
+func TestEnsureTentImage_MissingThenLoad(t *testing.T) {
+	podman, logPath := fakePodmanBinary(t, false)
+	tarball := filepath.Join(t.TempDir(), "tent.tar")
+	if err := os.WriteFile(tarball, []byte("fake tarball"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureTentImage(podman, "clown-tent:test", tarball); err != nil {
+		t.Fatalf("expected nil error from happy load, got %v", err)
+	}
+	data, _ := os.ReadFile(logPath)
+	if !strings.Contains(string(data), "load -i "+tarball) {
+		t.Errorf("expected `load -i %s` invocation; calls log:\n%s", tarball, data)
+	}
+}
+
+func TestEnsureTentImage_MissingNoTarball(t *testing.T) {
+	podman, _ := fakePodmanBinary(t, false)
+	err := ensureTentImage(podman, "clown-tent:test", "")
+	if err == nil || !strings.Contains(err.Error(), "not present locally") {
+		t.Fatalf("expected `not present locally` error when no tarball, got %v", err)
+	}
+}
+
+func TestEnsureClaudeJSON_LeavesExistingFileAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	want := []byte(`{"existing": "config"}`)
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureClaudeJSON(); err != nil {
+		t.Fatalf("ensureClaudeJSON: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("existing file rewritten; got %q want %q", got, want)
+	}
+}
+
+func TestEnsureClaudeJSON_CreatesEmptyJSONIfMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := ensureClaudeJSON(); err != nil {
+		t.Fatalf("ensureClaudeJSON: %v", err)
+	}
+	path := filepath.Join(home, ".claude.json")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file created at %s: %v", path, err)
+	}
+	if strings.TrimSpace(string(got)) != "{}" {
+		t.Errorf("initial content = %q, want %q", got, "{}")
+	}
+}
+
+func TestEnsureClaudeJSON_RejectsDirectoryAtPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ensureClaudeJSON()
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("expected `is a directory` error, got %v", err)
 	}
 }

--- a/cmd/clown/tent_loader.go
+++ b/cmd/clown/tent_loader.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+)
+
+// tent_loader.go renders `podman load -i <tarball>` as a bubbletea
+// program: a spinner row above a rolling tail of the most recent
+// output lines, like nix-build's live build window. Non-TTY callers
+// fall back to streaming raw podman output to stderr so CI logs
+// keep the full record.
+
+const (
+	// loaderMaxLines is how many of podman's most-recent output
+	// lines we keep visible under the spinner. Five lines is enough
+	// to see progress (one blob per line during `podman load`) without
+	// pushing the user's shell history off-screen.
+	loaderMaxLines = 5
+
+	loaderTitle = "Loading tent image (first run)…"
+)
+
+// runTentImageLoad runs `podman load -i tarball`. When stdout is a
+// TTY it uses the bubbletea live-tail UI; otherwise it streams raw
+// output to stderr (matching the prior behavior on CI). The combined
+// stdout+stderr of podman is always captured so a failure can dump
+// the full transcript regardless of UI mode.
+func runTentImageLoad(podmanPath, tarball string) error {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		return loadWithSpinner(context.Background(), podmanPath, tarball)
+	}
+	return loadStreaming(context.Background(), podmanPath, tarball)
+}
+
+// loadStreaming is the non-TTY path: forward podman output directly
+// to stderr while it runs. Used by CI, redirected stdout, and other
+// non-interactive environments.
+func loadStreaming(ctx context.Context, podmanPath, tarball string) error {
+	fmt.Fprintln(os.Stderr, loaderTitle)
+	cmd := exec.CommandContext(ctx, podmanPath, "load", "-i", tarball)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("podman load -i %s: %w", tarball, err)
+	}
+	return nil
+}
+
+// loadWithSpinner runs podman load under a bubbletea program that
+// shows a spinner and the last loaderMaxLines lines of output. On
+// success the tail collapses to a single "tent image cached" line;
+// on failure the captured transcript is dumped to stderr so the user
+// sees what podman complained about.
+func loadWithSpinner(ctx context.Context, podmanPath, tarball string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, podmanPath, "load", "-i", tarball)
+	pipeR, pipeW := io.Pipe()
+	cmd.Stdout = pipeW
+	cmd.Stderr = pipeW
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting podman load: %w", err)
+	}
+
+	model := newTentLoaderModel(loaderTitle, cancel)
+	program := tea.NewProgram(model)
+
+	// Forward output lines to the program AND capture them in a
+	// buffer for post-mortem display on failure. bytes.Buffer is
+	// safe for a single-writer goroutine.
+	var captured bytes.Buffer
+	teed := io.TeeReader(pipeR, &captured)
+	go func() {
+		scanner := bufio.NewScanner(teed)
+		// podman load lines stay well under 1 KiB but bump the
+		// scanner buffer anyway in case future versions emit long
+		// JSON progress events.
+		scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+		for scanner.Scan() {
+			program.Send(logLineMsg(scanner.Text()))
+		}
+	}()
+
+	cmdErrCh := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		// Closing the pipe writer unblocks the scanner goroutine.
+		_ = pipeW.Close()
+		cmdErrCh <- err
+		program.Send(doneMsg{err: err})
+	}()
+
+	if _, err := program.Run(); err != nil {
+		// bubbletea itself failed (rare). Make sure we don't leave
+		// podman running, then surface the error.
+		cancel()
+		<-cmdErrCh
+		return fmt.Errorf("running tent loader UI: %w", err)
+	}
+
+	cmdErr := <-cmdErrCh
+	if cmdErr != nil {
+		os.Stderr.Write(captured.Bytes())
+		return fmt.Errorf("podman load -i %s: %w", tarball, cmdErr)
+	}
+	return nil
+}
+
+// logLineMsg carries a single line of podman output into the
+// bubbletea Update loop.
+type logLineMsg string
+
+// doneMsg is sent when the podman process exits; nil err means
+// success.
+type doneMsg struct{ err error }
+
+// tentLoaderModel is the bubbletea Model that paints the spinner +
+// rolling log tail. Kept tiny: a fixed-size ring of recent lines and
+// a charmbracelet/bubbles spinner.
+type tentLoaderModel struct {
+	spinner  spinner.Model
+	title    string
+	lines    []string
+	maxLines int
+	done     bool
+	err      error
+	// cancel kills the podman child when the user hits Ctrl-C.
+	cancel context.CancelFunc
+}
+
+func newTentLoaderModel(title string, cancel context.CancelFunc) tentLoaderModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // cyan-ish
+	return tentLoaderModel{
+		spinner:  s,
+		title:    title,
+		maxLines: loaderMaxLines,
+		cancel:   cancel,
+	}
+}
+
+func (m tentLoaderModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m tentLoaderModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.Type == tea.KeyCtrlC {
+			if m.cancel != nil {
+				m.cancel()
+			}
+			// Don't tea.Quit yet — let the doneMsg arrive so we
+			// render the final state. cancel() will cause podman
+			// to exit, which sends doneMsg.
+			return m, nil
+		}
+		return m, nil
+	case logLineMsg:
+		m.lines = append(m.lines, string(msg))
+		if len(m.lines) > m.maxLines {
+			m.lines = m.lines[len(m.lines)-m.maxLines:]
+		}
+		return m, nil
+	case doneMsg:
+		m.done = true
+		m.err = msg.err
+		return m, tea.Quit
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+var (
+	loaderLogStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "240", Dark: "245"}).
+			PaddingLeft(2)
+	loaderSuccessStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	loaderFailureStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+)
+
+func (m tentLoaderModel) View() string {
+	if m.done {
+		if m.err != nil {
+			return loaderFailureStyle.Render("✗ "+m.title+" — failed") + "\n"
+		}
+		return loaderSuccessStyle.Render("✓ Tent image cached.") + "\n"
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%s %s\n", m.spinner.View(), m.title)
+	for _, line := range m.lines {
+		fmt.Fprintln(&b, loaderLogStyle.Render("│ "+line))
+	}
+	return b.String()
+}

--- a/cmd/clown/tent_loader_test.go
+++ b/cmd/clown/tent_loader_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTentLoader_LogLinesAppendUntilCap(t *testing.T) {
+	m := newTentLoaderModel("t", nil)
+	for i := 0; i < m.maxLines; i++ {
+		next, _ := m.Update(logLineMsg("line"))
+		m = next.(tentLoaderModel)
+	}
+	if got, want := len(m.lines), m.maxLines; got != want {
+		t.Fatalf("lines len = %d, want %d", got, want)
+	}
+}
+
+func TestTentLoader_LogLinesRingBuffersBeyondCap(t *testing.T) {
+	m := newTentLoaderModel("t", nil)
+	total := m.maxLines + 3
+	for i := 0; i < total; i++ {
+		next, _ := m.Update(logLineMsg("L"))
+		m = next.(tentLoaderModel)
+	}
+	if got, want := len(m.lines), m.maxLines; got != want {
+		t.Fatalf("ring should cap at %d, got %d", want, got)
+	}
+}
+
+func TestTentLoader_LogLinesRingKeepsMostRecent(t *testing.T) {
+	m := newTentLoaderModel("t", nil)
+	m.maxLines = 3
+	for _, line := range []string{"a", "b", "c", "d", "e"} {
+		next, _ := m.Update(logLineMsg(line))
+		m = next.(tentLoaderModel)
+	}
+	want := []string{"c", "d", "e"}
+	if len(m.lines) != 3 {
+		t.Fatalf("expected 3 lines, got %v", m.lines)
+	}
+	for i, w := range want {
+		if m.lines[i] != w {
+			t.Errorf("lines[%d] = %q, want %q", i, m.lines[i], w)
+		}
+	}
+}
+
+func TestTentLoader_DoneMsgRecordsError(t *testing.T) {
+	m := newTentLoaderModel("t", nil)
+	next, cmd := m.Update(doneMsg{err: errFake("boom")})
+	m = next.(tentLoaderModel)
+	if !m.done {
+		t.Error("done should be true after doneMsg")
+	}
+	if m.err == nil || m.err.Error() != "boom" {
+		t.Errorf("err = %v, want `boom`", m.err)
+	}
+	if cmd == nil {
+		t.Error("doneMsg should return a tea.Quit command")
+	}
+}
+
+func TestTentLoader_ViewInProgressShowsLinesUnderSpinner(t *testing.T) {
+	m := newTentLoaderModel("Loading…", nil)
+	next, _ := m.Update(logLineMsg("Copying blob abc"))
+	m = next.(tentLoaderModel)
+	out := m.View()
+	if !strings.Contains(out, "Loading…") {
+		t.Errorf("view missing title: %q", out)
+	}
+	if !strings.Contains(out, "Copying blob abc") {
+		t.Errorf("view missing log line: %q", out)
+	}
+}
+
+func TestTentLoader_ViewDoneSuccessShowsCheckmark(t *testing.T) {
+	m := newTentLoaderModel("Loading…", nil)
+	next, _ := m.Update(doneMsg{err: nil})
+	m = next.(tentLoaderModel)
+	out := m.View()
+	if !strings.Contains(out, "Tent image cached") {
+		t.Errorf("view missing cached message: %q", out)
+	}
+	if !strings.Contains(out, "✓") {
+		t.Errorf("view missing success glyph: %q", out)
+	}
+}
+
+func TestTentLoader_ViewDoneFailureShowsCrossmark(t *testing.T) {
+	m := newTentLoaderModel("Loading…", nil)
+	next, _ := m.Update(doneMsg{err: errFake("nope")})
+	m = next.(tentLoaderModel)
+	out := m.View()
+	if !strings.Contains(out, "failed") {
+		t.Errorf("view missing failure message: %q", out)
+	}
+	if !strings.Contains(out, "✗") {
+		t.Errorf("view missing failure glyph: %q", out)
+	}
+}
+
+func TestTentLoader_CtrlCCancelsAndKeepsModel(t *testing.T) {
+	called := false
+	cancel := func() { called = true }
+	m := newTentLoaderModel("Loading…", cancel)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		t.Error("Ctrl-C handler must wait for doneMsg, not quit immediately")
+	}
+	if next == nil {
+		t.Fatal("Update returned nil model")
+	}
+	if !called {
+		t.Error("Ctrl-C should call cancel()")
+	}
+}
+
+// errFake is a minimal error implementation for tests.
+type errFake string
+
+func (e errFake) Error() string { return string(e) }

--- a/docs/features/0007-tent.md
+++ b/docs/features/0007-tent.md
@@ -228,6 +228,38 @@ Each likely warrants its own ADR.
   is a natural extension and is mentioned in adjacent RFCs, but
   is out of scope for the initial cut.
 
+## Tracer-bullet status (2026-05-10)
+
+A first cut has landed under `--tent`, deliberately scoped to prove
+the wrapping mechanism end-to-end rather than to answer the gating
+ADR questions. Committed:
+
+- **Sandbox tech**: podman (`pkgs.podman` linux-only). Image built
+  via `dockerTools.buildLayeredImage`; `/nix/store` is bind-mounted
+  read-only so the claude binary is referenced by its store path
+  rather than baked into the image.
+- **Coverage**: claude only. Codex/crush/opencode/circus paths
+  unchanged.
+- **Activation**: opt-in. `--tent` (or `CLOWN_TENT=1`) wraps; the
+  un-tented path is the default and is byte-for-byte unchanged.
+- **Network**: `--network=host` so plugin-host loopback URLs
+  continue to work without bridging.
+- **Working surface**: `$PWD` writable, `/nix/store` ro,
+  `~/.claude` and `~/.config/claude` writable, `$TMPDIR` writable
+  (for plugin-host's staged manifest dirs).
+
+Deferred to follow-ups: egress allowlisting, per-provider profiles,
+codex/crush/opencode/circus support, hook-bridge integration
+(RFC-0007), audit logging, macOS posture. The bypassability story
+(#62, claude-code 2.1.123+ bump) is *unblocked but not closed* by
+this cut — making tent the default and removing the binary-patch
+load on managed-settings remain follow-ups.
+
+Code pointers: `cmd/clown/main.go` (flag + `tentExecutor`),
+`internal/tent/tent.go` (argv builder), `internal/buildcfg`
+(`PodmanPath`, `TentImageRef`, `TentImageTarball`), `flake.nix`
+(`tentImage`, ldflags).
+
 ## Provisional recommendation
 
 If forced to commit today: **standardize on fence** as the

--- a/flake.nix
+++ b/flake.nix
@@ -389,6 +389,53 @@
         defaultDefaultProvider = "claude";
         defaultDefaultProfile = "claude-anthropic";
 
+        # tent: podman-wrapped provider container. FDR-0007.
+        # Tracer-bullet scope: claude only, opt-in via --tent.
+        # podman is currently linux-only in this build; on darwin
+        # podman requires a VM and is out of scope for v1, so we
+        # leave tentPodmanPath empty there and the runtime emits a
+        # clear "not wired in" error if --tent is used.
+        tentEnabled = pkgs.stdenv.isLinux;
+        tentImage =
+          if tentEnabled then
+            pkgs.dockerTools.buildLayeredImage {
+              name = "clown-tent";
+              tag = clownVersion;
+              # The image deliberately does not bake claude in —
+              # /nix/store is bind-mounted read-only at runtime and
+              # the claude binary is referenced by its store path.
+              # The image only needs the tiny set of utilities that
+              # podman expects to find inside (and CA certs for
+              # HTTPS to api.anthropic.com).
+              contents = [
+                pkgs.bashInteractive
+                pkgs.coreutils
+                pkgs.cacert
+                pkgs.iana-etc
+              ];
+              config = {
+                Env = [
+                  "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                  "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                  # Pin the in-container locale to C.UTF-8 (built into
+                  # glibc 2.35+, no locale archive needed). Avoids the
+                  # `setlocale: cannot change locale (en_US.UTF-8)`
+                  # warnings every subshell prints when the host's
+                  # LC_ALL/LANG leak in but no locale archive is
+                  # reachable inside the namespace. The tent.go
+                  # DefaultEnvPassthrough deliberately omits LC_ALL
+                  # and LANG so these defaults win.
+                  "LC_ALL=C.UTF-8"
+                  "LANG=C.UTF-8"
+                ];
+              };
+            }
+          else
+            null;
+        tentImageRef = if tentEnabled then "clown-tent:${clownVersion}" else "";
+        tentImageTarball = if tentEnabled then "${tentImage}" else "";
+        tentPodmanPath = if tentEnabled then "${pkgs.podman}/bin/podman" else "";
+
         mkClownGo =
           {
             defaultProvider ? defaultDefaultProvider,
@@ -421,6 +468,9 @@
               "-X github.com/amarbel-llc/clown/internal/buildcfg.StdioBridgePath=${clown-stdio-bridge}/bin/clown-stdio-bridge"
               "-X github.com/amarbel-llc/clown/internal/buildcfg.DefaultProvider=${defaultProvider}"
               "-X github.com/amarbel-llc/clown/internal/buildcfg.DefaultProfile=${defaultProfile}"
+              "-X github.com/amarbel-llc/clown/internal/buildcfg.PodmanPath=${tentPodmanPath}"
+              "-X github.com/amarbel-llc/clown/internal/buildcfg.TentImageRef=${tentImageRef}"
+              "-X github.com/amarbel-llc/clown/internal/buildcfg.TentImageTarball=${tentImageTarball}"
             ];
           };
 

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,20 @@ module github.com/amarbel-llc/clown
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	golang.org/x/term v0.42.0
 )
 
 require (
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/buildcfg/buildcfg.go
+++ b/internal/buildcfg/buildcfg.go
@@ -37,4 +37,19 @@ var (
 	// explicit --profile would. Empty disables the build-time
 	// default and restores the picker / hardcoded-provider flow.
 	DefaultProfile string
+	// PodmanPath is the absolute path to the podman binary, baked
+	// at build time. Consumed by the --tent codepath to wrap the
+	// provider in a container. Empty in dev builds; --tent fails
+	// fast with a clear error when empty. See FDR-0007.
+	PodmanPath string
+	// TentImageRef is the podman image reference (e.g.
+	// "clown-tent:1.2.3") that --tent runs the provider inside.
+	// Loaded on demand from TentImageTarball when not already
+	// present in the local podman image store. Empty in dev builds.
+	TentImageRef string
+	// TentImageTarball is the absolute path to a docker-format
+	// image tarball produced by dockerTools.buildImage. clown runs
+	// `podman load -i <tarball>` on first --tent invocation if the
+	// image is not already in the local store. Empty in dev builds.
+	TentImageTarball string
 )

--- a/internal/tent/tent.go
+++ b/internal/tent/tent.go
@@ -1,0 +1,203 @@
+// Package tent builds the podman invocation that wraps a provider
+// binary. It is consumed by cmd/clown's tentExecutor; everything in
+// here is pure (no IO) so the argv shape is testable in isolation.
+//
+// FDR-0007 (docs/features/0007-tent.md) is the design record. This
+// package implements the tracer-bullet shape: opt-in, claude-only,
+// --network=host, /nix/store bind-mounted read-only, working tree
+// and ~/.claude bind-mounted writable.
+package tent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Options describes the container shape tent should construct. Zero
+// values are not meaningful — callers should populate at least Image,
+// Workdir, and Home (OptionsFromEnv does this).
+type Options struct {
+	// Image is the podman image reference (e.g. "clown-tent:1.2.3").
+	Image string
+
+	// Workdir is the host path that becomes the container's working
+	// directory. Bind-mounted at the same path inside the container.
+	Workdir string
+
+	// Home is the user's home directory on the host. ~/.claude and
+	// ~/.config/claude are bind-mounted writable so provider creds
+	// and config persist across runs.
+	Home string
+
+	// TmpDir is the host temp directory (typically /tmp). Bind-
+	// mounted writable so the plugin-host pipeline's staged plugin
+	// dirs (created via os.MkdirTemp) are reachable from inside the
+	// container at the same path. Pass an empty string to skip.
+	TmpDir string
+
+	// PluginDirs lists host paths to bind-mount read-only. The raw
+	// (user-facing) plugin directories — anything under /nix/store
+	// is already covered by the read-only /nix/store mount, so this
+	// is mainly for --plugin-dir paths supplied at the command line.
+	PluginDirs []string
+
+	// EnvPassthrough lists environment variable names whose values
+	// should be forwarded into the container. Anything not in this
+	// list is intentionally invisible to the wrapped provider.
+	EnvPassthrough []string
+
+	// Tty signals that podman should allocate a pseudo-TTY (-t).
+	// Claude's TUI requires this when stdin and stdout are real
+	// terminals; in non-interactive contexts (--print mode, CI
+	// pipelines) -t mangles output and must stay off.
+	Tty bool
+}
+
+// DefaultEnvPassthrough is the env-var allowlist for the tracer
+// bullet. Narrow on purpose: HOME/USER/TERM for a usable shell,
+// ANTHROPIC_API_KEY for claude auth, NO_PROXY/HTTP(S)_PROXY for
+// users behind a corporate proxy.
+//
+// XDG vars are forwarded so claude finds its config under
+// $XDG_CONFIG_HOME/claude when set. If a user points XDG_CONFIG_HOME
+// at a non-default path, the corresponding directory must also be
+// bind-mounted into the container — the tracer bullet only mounts
+// ~/.claude and ~/.config/claude. Custom XDG path mounting is a
+// follow-up (tracked alongside per-provider profiles in FDR-0007).
+//
+// LANG and LC_ALL are deliberately NOT in this list. The tent image
+// pins both to C.UTF-8 in its Env config (see flake.nix) because
+// glibc 2.35+ has C.UTF-8 built in but no archive for the host's
+// typical en_US.UTF-8 is reachable inside the namespace, which would
+// otherwise produce a `setlocale: cannot change locale` warning on
+// every subshell. claude's TUI only needs UTF-8 char handling, not
+// en_US collation/date formatting.
+var DefaultEnvPassthrough = []string{
+	"HOME",
+	"USER",
+	"TERM",
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_AUTH_TOKEN",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_STATE_HOME",
+	"XDG_CACHE_HOME",
+}
+
+// OptionsFromEnv builds Options from the process environment.
+// `image` is the buildcfg-baked image reference; `pluginDirs` is the
+// post-compilation plugin dir list from the plugin-host pipeline.
+func OptionsFromEnv(image string, pluginDirs []string) (Options, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return Options{}, fmt.Errorf("tent: getwd: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Options{}, fmt.Errorf("tent: userhomedir: %w", err)
+	}
+	return Options{
+		Image:          image,
+		Workdir:        cwd,
+		Home:           home,
+		TmpDir:         os.TempDir(),
+		PluginDirs:     pluginDirs,
+		EnvPassthrough: DefaultEnvPassthrough,
+		Tty:            stdioIsTerminal(),
+	}, nil
+}
+
+// stdioIsTerminal reports whether both stdin and stdout are TTYs.
+// We require both: -t with a non-terminal stdout mangles output (the
+// PTY layer adds CRLF / ANSI escapes that downstream consumers
+// don't expect), and -t with non-terminal stdin gives podman no
+// place to wire the master end of the pty.
+func stdioIsTerminal() bool {
+	return isCharDevice(os.Stdin) && isCharDevice(os.Stdout)
+}
+
+func isCharDevice(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// BuildArgs assembles the full podman argv that runs `claudeBinary
+// claudeArgs...` inside the tent container. The first element is the
+// podman subcommand ("run"); callers prepend the podman binary path
+// as argv[0] separately.
+//
+// Shape (mounts elided for brevity):
+//
+//	run --rm -i --network=host --userns=keep-id
+//	    --volume /nix/store:/nix/store:ro
+//	    --volume <workdir>:<workdir>
+//	    --volume <home>/.claude:<home>/.claude
+//	    --volume <home>/.config/claude:<home>/.config/claude
+//	    --volume <plugin-dir>:<plugin-dir>:ro       (per dir)
+//	    --workdir <workdir>
+//	    --env <NAME>                                 (per allowlisted var)
+//	    <image>
+//	    <claudeBinary> <claudeArgs...>
+func BuildArgs(claudeBinary string, claudeArgs []string, opts Options) []string {
+	args := []string{
+		"run",
+		"--rm",
+		"-i",
+	}
+	if opts.Tty {
+		args = append(args, "-t")
+	}
+	args = append(args,
+		"--network=host",
+		"--userns=keep-id",
+		"--volume", "/nix/store:/nix/store:ro",
+	)
+
+	if opts.Workdir != "" {
+		args = append(args, "--volume", fmt.Sprintf("%s:%s", opts.Workdir, opts.Workdir))
+	}
+	if opts.Home != "" {
+		claudeDir := filepath.Join(opts.Home, ".claude")
+		configDir := filepath.Join(opts.Home, ".config", "claude")
+		claudeJSON := filepath.Join(opts.Home, ".claude.json")
+		args = append(args,
+			"--volume", fmt.Sprintf("%s:%s", claudeDir, claudeDir),
+			"--volume", fmt.Sprintf("%s:%s", configDir, configDir),
+			"--volume", fmt.Sprintf("%s:%s", claudeJSON, claudeJSON),
+		)
+	}
+	if opts.TmpDir != "" {
+		args = append(args, "--volume", fmt.Sprintf("%s:%s", opts.TmpDir, opts.TmpDir))
+	}
+	for _, dir := range opts.PluginDirs {
+		if dir == "" {
+			continue
+		}
+		args = append(args, "--volume", fmt.Sprintf("%s:%s:ro", dir, dir))
+	}
+
+	if opts.Workdir != "" {
+		args = append(args, "--workdir", opts.Workdir)
+	}
+	for _, name := range opts.EnvPassthrough {
+		if name == "" {
+			continue
+		}
+		args = append(args, "--env", name)
+	}
+
+	args = append(args, opts.Image, claudeBinary)
+	args = append(args, claudeArgs...)
+	return args
+}

--- a/internal/tent/tent_test.go
+++ b/internal/tent/tent_test.go
@@ -1,0 +1,151 @@
+package tent
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestBuildArgs_DefaultShape(t *testing.T) {
+	opts := Options{
+		Image:          "clown-tent:test",
+		Workdir:        "/home/u/repo",
+		Home:           "/home/u",
+		TmpDir:         "/tmp",
+		EnvPassthrough: []string{"HOME", "ANTHROPIC_API_KEY"},
+	}
+	got := BuildArgs("/nix/store/aaa-claude/bin/claude", []string{"--version"}, opts)
+
+	wantHead := []string{
+		"run", "--rm", "-i",
+		"--network=host", "--userns=keep-id",
+		"--volume", "/nix/store:/nix/store:ro",
+		"--volume", "/home/u/repo:/home/u/repo",
+		"--volume", "/home/u/.claude:/home/u/.claude",
+		"--volume", "/home/u/.config/claude:/home/u/.config/claude",
+		"--volume", "/home/u/.claude.json:/home/u/.claude.json",
+		"--volume", "/tmp:/tmp",
+		"--workdir", "/home/u/repo",
+		"--env", "HOME",
+		"--env", "ANTHROPIC_API_KEY",
+		"clown-tent:test",
+		"/nix/store/aaa-claude/bin/claude",
+		"--version",
+	}
+	if !slices.Equal(got, wantHead) {
+		t.Fatalf("argv mismatch:\n got: %q\nwant: %q", got, wantHead)
+	}
+}
+
+func TestBuildArgs_TtyAddsDashT(t *testing.T) {
+	opts := Options{
+		Image:   "img",
+		Workdir: "/w",
+		Home:    "/h",
+		Tty:     true,
+	}
+	got := BuildArgs("/c", nil, opts)
+
+	tIdx := slices.Index(got, "-t")
+	iIdx := slices.Index(got, "-i")
+	if tIdx == -1 {
+		t.Fatalf("-t flag missing when Tty=true; got %q", got)
+	}
+	if tIdx != iIdx+1 {
+		t.Errorf("-t should immediately follow -i; got -i at %d, -t at %d", iIdx, tIdx)
+	}
+}
+
+func TestBuildArgs_NoTtyOmitsDashT(t *testing.T) {
+	opts := Options{Image: "img", Workdir: "/w", Home: "/h"}
+	got := BuildArgs("/c", nil, opts)
+	if slices.Contains(got, "-t") {
+		t.Errorf("-t must not appear when Tty=false; got %q", got)
+	}
+}
+
+func TestBuildArgs_PluginDirsMountedReadOnly(t *testing.T) {
+	opts := Options{
+		Image:      "clown-tent:test",
+		Workdir:    "/w",
+		Home:       "/h",
+		PluginDirs: []string{"/tmp/staged-a", "/tmp/staged-b"},
+	}
+	got := BuildArgs("/c", nil, opts)
+
+	if !containsPair(got, "--volume", "/tmp/staged-a:/tmp/staged-a:ro") {
+		t.Errorf("missing read-only mount for plugin dir a; got %q", got)
+	}
+	if !containsPair(got, "--volume", "/tmp/staged-b:/tmp/staged-b:ro") {
+		t.Errorf("missing read-only mount for plugin dir b; got %q", got)
+	}
+}
+
+func TestBuildArgs_ClaudeArgsPreservedAtEnd(t *testing.T) {
+	opts := Options{Image: "img", Workdir: "/w", Home: "/h"}
+	got := BuildArgs("/c", []string{"--foo", "bar", "--baz=qux"}, opts)
+
+	if got[len(got)-4] != "/c" {
+		t.Fatalf("claude binary not at expected position: got %q", got)
+	}
+	tail := got[len(got)-3:]
+	want := []string{"--foo", "bar", "--baz=qux"}
+	if !slices.Equal(tail, want) {
+		t.Fatalf("claude args mangled: got %q want %q", tail, want)
+	}
+}
+
+func TestBuildArgs_ImageImmediatelyBeforeBinary(t *testing.T) {
+	opts := Options{Image: "img:1", Workdir: "/w", Home: "/h"}
+	got := BuildArgs("/bin/claude", []string{"a"}, opts)
+
+	idx := slices.Index(got, "img:1")
+	if idx == -1 {
+		t.Fatalf("image not in argv: %q", got)
+	}
+	if got[idx+1] != "/bin/claude" {
+		t.Fatalf("image not immediately followed by binary: %q", got)
+	}
+}
+
+func TestBuildArgs_NoNixStoreWritable(t *testing.T) {
+	opts := Options{Image: "img", Workdir: "/w", Home: "/h"}
+	got := BuildArgs("/c", nil, opts)
+
+	for i, a := range got {
+		if a == "--volume" && i+1 < len(got) && strings.HasPrefix(got[i+1], "/nix/store:") {
+			if !strings.HasSuffix(got[i+1], ":ro") {
+				t.Fatalf("/nix/store mount must be read-only: %q", got[i+1])
+			}
+		}
+	}
+}
+
+func TestBuildArgs_NoBlankEnvOrPluginDirs(t *testing.T) {
+	opts := Options{
+		Image:          "img",
+		Workdir:        "/w",
+		Home:           "/h",
+		PluginDirs:     []string{"", "/real"},
+		EnvPassthrough: []string{"", "REAL"},
+	}
+	got := BuildArgs("/c", nil, opts)
+
+	if containsPair(got, "--volume", ":") || containsPair(got, "--volume", "::ro") {
+		t.Errorf("blank plugin dir produced a mount: %q", got)
+	}
+	for i, a := range got {
+		if a == "--env" && i+1 < len(got) && got[i+1] == "" {
+			t.Errorf("blank env var name passed through: idx %d", i)
+		}
+	}
+}
+
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/zz-explore/justfile
+++ b/zz-explore/justfile
@@ -398,3 +398,46 @@ issue-35-mkcircus-plugin-closure:
     else
         echo "   (no clown-plugin-meta found in closure — unexpected)"
     fi
+
+# Tent-relevant: confirm that podman --volume precedence honors the
+# more-specific (child) bind even when its parent is also bind-mounted
+# writable. Tent mounts $TMPDIR writable AND staged plugin dirs (which
+# live under $TMPDIR via os.MkdirTemp) read-only — if podman didn't
+# honor the inner mount we'd have a silent write-through hole. Uses
+# docker.io/library/busybox (small, ~5 MiB pull on first run).
+#
+# Pass criteria:
+#   - PARENT_WRITE_OK             (writable bind works as advertised)
+#   - CHILD_WRITE_BLOCKED         (inner :ro bind shadows parent)
+tent-mount-precedence:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    work=$(mktemp -d)
+    trap 'rm -rf "$work"' EXIT
+
+    mkdir -p "$work/parent/child"
+    echo preexisting > "$work/parent/file.txt"
+    echo preexisting > "$work/parent/child/file.txt"
+
+    echo "=== running busybox with parent writable, parent/child :ro ==="
+    /usr/bin/podman run --rm \
+      --volume "$work/parent:$work/parent" \
+      --volume "$work/parent/child:$work/parent/child:ro" \
+      docker.io/library/busybox:latest \
+      sh -c "
+        set +e
+        echo '-- parent write attempt (expect OK) --'
+        touch '$work/parent/wrote_parent' && echo PARENT_WRITE_OK || echo PARENT_WRITE_FAIL
+        echo '-- parent/child write attempt (expect blocked) --'
+        touch '$work/parent/child/wrote_child' 2>&1 | head -1
+        if [ -f '$work/parent/child/wrote_child' ]; then
+            echo CHILD_WRITE_OK_UNEXPECTED
+        else
+            echo CHILD_WRITE_BLOCKED
+        fi
+        echo '-- /proc/mounts entries for test paths --'
+        grep -F \"$work/parent\" /proc/mounts || true
+      "
+    echo
+    echo "=== host-side post-state ==="
+    ls -la "$work/parent" "$work/parent/child"


### PR DESCRIPTION
Implements the first cut of FDR-0007 (tent). `clown --tent --provider
claude` (or `CLOWN_TENT=1`) wraps the claude exec in a podman
container with /nix/store read-only, $PWD + ~/.claude + $TMPDIR
writable, and --network=host so plugin-host loopback URLs keep
working. Un-tented paths are unchanged; --tent is mutually exclusive
with --naked.

The tent image is built via dockerTools.buildLayeredImage and
loaded on-demand (`podman load -i <tarball>`) the first time the
image ref is missing from the local store. Podman/image/tarball
paths are linker-baked through new buildcfg fields and are empty
on non-linux builds, where --tent fails fast with a clear error.