### PR TITLE
docs: design the cloud-tent pivot (FDR-0014, RFC-0012)

### DIFF
--- a/docs/features/0007-tent.md
+++ b/docs/features/0007-tent.md
@@ -1,6 +1,7 @@
 ---
 status: testing
 date: 2026-05-09
+superseded-by: FDR-0014 (cloud tent — local-container substrate retired; policy goal preserved)
 promotion-criteria: tent is the default execution path for claude on a supported platform (linux native or darwin via podman-machine); the only escape is `--no-tent` / FDR-0009's `--naked`; the unbypassable-settings invariant is enforceable through tent-as-the-boundary rather than through the binary cli.js patch on every platform; the loopback / plugin-host reachability story is documented and tested across platforms
 ---
 

--- a/docs/features/0012-tent-narrow-userspace-and-hook-tunnel.md
+++ b/docs/features/0012-tent-narrow-userspace-and-hook-tunnel.md
@@ -1,6 +1,7 @@
 ---
 status: exploring
 date: 2026-05-27
+superseded-by: FDR-0014 (cloud tent — the cross-arch problem this record addresses is removed by the cloud substrate)
 promotion-criteria: cross-arch papercuts (Mach-O bash, host nix-store leak-through, --tent-pass-devshell PATH races) eliminated by construction; a host-side hook tunnel exists and survives a representative plugin set (docs-r-us, eng:*, course-correct, spinclass) without per-plugin tent-awareness; agent-driven git work via grit MCP matches the ergonomics of agent-driven git work via in-tent `git` today; clown depends on moxy as a documented peer
 ---
 

--- a/docs/features/0014-cloud-tent.md
+++ b/docs/features/0014-cloud-tent.md
@@ -96,6 +96,16 @@ operator's machine                         cloud (DigitalOcean)
   path, firewall expectations, hostname convention — is **RFC-0012**, so eng
   and clown version independently.
 
+**The tent replaces the working tree; it does not mirror it.** The local tent
+bind-mounted `$PWD` so the agent edited the operator's on-disk tree. A cloud
+tent does the opposite: it **holds its own git clones** and the agent works
+directly against them on the VM — the same model as a fresh remote-execution
+environment, where the repo is cloned on session start and work flows back
+through ordinary `git push`. There is no rsync/mutagen sync layer and no
+`$PWD` bind, because the operator's local checkout is not in the loop at all.
+The host runs the orchestration CLI and a Tailscale client; the *code* lives on
+the tent.
+
 ## Interface (sketch — to be firmed in `proposed`)
 
 ```sh
@@ -146,14 +156,20 @@ FDR-0014**" banner rather than being rewritten.
 
 ## Non-goals / open questions
 
-1. **Working-tree delivery.** How the operator's local repo reaches the cloud
-   tent (push a branch and clone? mutagen/rsync over Tailscale SSH? work
-   entirely cloud-side?) is the biggest unanswered design question and is
-   deferred to `proposed`. The local tent bind-mounted `$PWD`; a cloud tent
-   cannot.
-2. **Ephemeral vs. reattachable.** Per-session throwaway droplets (clean, but
-   slow cold-start and repeated clone cost) vs. a long-lived per-operator tent
-   you reattach to. Likely a knob.
+1. **Repo-clone credentials (resolved framing).** The working-tree question is
+   *not* "how does the local tree reach the tent" — the tent clones the repos
+   itself (above). The real question is how the tent authenticates those clones
+   (and pushes): a GitHub token / deploy key delivered alongside the auth key at
+   first boot, ssh-agent forwarded over Tailscale SSH, or the operator cloning
+   manually after connect. Tailscale SSH makes operator-driven clone trivial;
+   automated provisioning needs a credential channel. Which repos to clone (and
+   from where) is itself a provisioning input. Deferred to `proposed`.
+2. **Ephemeral vs. reattachable + commit discipline.** Because the tent holds
+   the only copy of in-progress work, per-session throwaway droplets lose
+   anything uncommitted on `down`. Either the tent is long-lived/reattachable,
+   or `down` enforces commit+push first (or warns on a dirty tree) — the same
+   discipline a remote-execution session already lives by. Likely a knob with a
+   safe default (refuse to destroy a dirty tent).
 3. **Cost / lifecycle hygiene.** Cloud tents cost money and leak if not
    destroyed; `down` must be reliable and a sweep for orphaned droplets is
    probably required.

--- a/docs/features/0014-cloud-tent.md
+++ b/docs/features/0014-cloud-tent.md
@@ -1,0 +1,177 @@
+---
+status: exploring
+date: 2026-06-09
+supersedes: FDR-0007, FDR-0012
+promotion-criteria: >
+  exploring -> proposed: this record + RFC-0012 (clown↔eng provisioning
+  contract) reviewed; eng FDR-0005 (the NixOS image) accepted in `proposed`;
+  the deprecation plan for the local podman/lima tent is agreed (kept building,
+  marked deprecated, removed in a named follow-up).
+  proposed -> experimental: `clown --tent up` provisions a DigitalOcean droplet
+  from the eng-built NixOS image, the droplet auto-joins the operator's tailnet,
+  and `clown --tent` reaches the agent loop on it; `clown --tent down` destroys
+  it and the ephemeral node self-evicts. The local podman/lima path still builds
+  but is no longer the documented tent.
+  experimental -> testing: provision/connect/destroy is reliable across repeated
+  cycles, the auth key never lands in the store or image, and the working-tree
+  delivery story (how the user's repo reaches the cloud tent) is documented and
+  tested.
+  testing -> accepted: cloud tent is the default meaning of `--tent`; the local
+  podman/lima implementation, the `tentBackend` build lever, the lima
+  home-manager module, and the dev-tent recipes are removed; Hetzner builds from
+  the same eng module set.
+---
+
+# Cloud Tent — Tents as Cloud-Hosted NixOS VMs
+
+## Problem Statement
+
+FDR-0007 defined **tent** as "the environment the harness sees" — the trust
+boundary that enforces clown's unbypassable-settings invariant by controlling
+the filesystem, network, and command surface around the agent. The chosen
+substrate was a **local container**: podman on linux, podman-machine on darwin,
+with a lima alternative (FDR-0007, clown#99/#100). FDR-0012 then spent its
+entire problem statement documenting how badly that substrate fits darwin —
+the host Nix store holds Mach-O binaries that cannot execute in a linux
+container, every shebang-less subprocess in a plugin hook hits
+`Exec format error` (#44), the mount list grew reactively (eng#107/108/112),
+and `--tent-pass-devshell` races silently rewrite PATH.
+
+The local-container substrate carries structural costs that no amount of
+mount-list tuning removes:
+
+1. **Cross-arch impedance** (FDR-0012): a linux container on a darwin host is
+   a permanent arch-mismatch hazard. The eng dev loop documents the pain — a
+   full `home-manager switch` → `podman machine rm -f` → `launchctl kickstart`
+   round-trip just to change a bind mount.
+2. **One-VM-at-a-time on darwin**: podman-machine enforces
+   `RequireExclusiveActive()` across every darwin provider, so clown's own
+   dev loop is a "stop/swap" dance that takes the eng-managed VM offline
+   (AGENTS.md "Dev loop for tent"). Lima was explored specifically to escape
+   this (clown#99).
+3. **Host-coupling**: the tent's capabilities are bounded by the host's
+   hypervisor, its Nix store, its podman-machine config — the boundary is only
+   as strong and as portable as the laptop it runs on. ssh-agent forwarding
+   needs a bespoke `ssh -R` bridge because virtiofs can't proxy AF_UNIX
+   (containers/podman#23245).
+
+The pivot: **stop hosting the tent on the operator's machine. Host it in the
+cloud.** A tent becomes a cloud VM — DigitalOcean first, Hetzner later — booted
+from a reproducible NixOS image (eng FDR-0005) that joins the operator's
+tailnet on first boot. The containment boundary is now a whole machine the
+operator does not own the kernel of, reachable only over Tailscale; the
+cross-arch problem disappears (the guest is always linux/amd64 regardless of a
+darwin host); the one-VM rule disappears (provision as many tents as you'll
+pay for); and the host's only job is to run the orchestration CLI and a
+Tailscale client.
+
+This supersedes FDR-0007's "local container" substrate and the entire
+FDR-0012 narrow-userspace effort (which was a response to the local-container
+arch problem that the cloud substrate eliminates by construction). The *policy
+goal* of FDR-0007 — bound the agent's blast radius so broad Bash permissions
+are safe — is preserved; only the substrate changes.
+
+## What a cloud tent is
+
+```
+operator's machine                         cloud (DigitalOcean)
+┌────────────────────┐                     ┌──────────────────────────┐
+│ clown --tent (CLI) │                     │  NixOS droplet (the tent) │
+│   └─ OpenTofu      │── DO API ──────────▶│   - eng-built image       │
+│   └─ tailscale     │── TS API (mint key)▶│   - services.tailscale    │
+│   client           │                     │   - the agent loop        │
+└─────────┬──────────┘                     └────────────┬─────────────┘
+          └──────────────  Tailscale  ──────────────────┘
+                    (only reachable over the tailnet)
+```
+
+- **eng** owns the image (eng FDR-0005): a NixOS system that boots configured
+  to join the tailnet via an ephemeral, pre-authorized, single-use auth key
+  delivered through provider user-data into guest tmpfs.
+- **clown** owns the CLI and the provisioning. `clown --tent` drives OpenTofu
+  (the chosen orchestration engine) to: register the image, mint the tailnet
+  key (operator's tailnet, via the operator's Tailscale credentials), create
+  the droplet + a deny-all-but-Tailscale firewall, and tear it all down.
+- The contract between the two repos — image format, the user-data auth-key
+  path, firewall expectations, hostname convention — is **RFC-0012**, so eng
+  and clown version independently.
+
+## Interface (sketch — to be firmed in `proposed`)
+
+```sh
+clown --tent up            # tofu apply: image + authkey + droplet + firewall
+clown --tent               # connect to the running tent, run the agent there
+clown --tent down          # tofu destroy: droplet gone; ephemeral node self-evicts
+clown --tent status        # tofu/tailscale state of the current tent
+```
+
+`--tent` with no subcommand keeps its FDR-0007 meaning ("run the agent in the
+tent") but now resolves to the cloud VM. `--no-tent` / FDR-0009 `--naked`
+remain the escapes. Whether the cloud tent is per-session-ephemeral or a
+longer-lived reattachable VM is an open question (below).
+
+Provisioning is **OpenTofu**, not native Go: the ts-do-piho prior art
+(`friedenberg/ts-do-piho`) already encodes the DO-droplet + tailnet-key +
+firewall shape in tofu HCL with the `digitalocean` and `tailscale` providers,
+and tofu's state model handles the create/destroy lifecycle clown would
+otherwise hand-roll. clown ships the HCL and shells out to `tofu`
+(discovered/pinned via Nix), reading droplet IP / tailnet name back from tofu
+outputs.
+
+## Deprecation of the local-container tent
+
+Per the pivot decision, the local podman/lima implementation is **deprecated,
+not deleted yet** — it keeps building while the cloud path is proven, and is
+removed in a named follow-up (gated by this FDR reaching `accepted`). The
+surface to retire, for the eventual removal PR:
+
+- **Go**: `internal/tent/` (the `tent.Backend` interface —
+  `ImageExistsArgs`/`LoadImageArgs`/`RunArgs`/`Binary()` — its podman and lima
+  impls, and `tent.BuildArgs`); `cmd/clown/`'s `newBackend()`,
+  `ensureTentImage`, `runTentImageLoad`, and `tentExecutor` wiring.
+- **buildcfg**: `PodmanPath`, `PodmanMachineName`, `LimactlPath`, `TentBackend`
+  ldflags.
+- **flake**: the `tentBackend` parameter on `mkClownGo`/`mkClownPkg`/`mkCircus`,
+  `packages.dev` / `packages.dev-lima`, `devTentVolumes`, and
+  `homeManagerModules.tent-backend-lima`.
+- **justfile**: the `dev-tent-*` / `smoke-dev-tent` family and
+  `dev-tent-ssh-forward`.
+- **POCs/tests**: `zz-pocs/tent-lima/`, the tent bats.
+- **eng**: `programs.podman-darwin` and the `enable-tent-claude` identity
+  field become cloud-tent-irrelevant once removal lands (coordinate via eng).
+
+Until removal, AGENTS.md's "Dev loop for tent", "Lima home-manager module",
+and "Tent backend lever" sections gain a one-line "**deprecated — see
+FDR-0014**" banner rather than being rewritten.
+
+## Non-goals / open questions
+
+1. **Working-tree delivery.** How the operator's local repo reaches the cloud
+   tent (push a branch and clone? mutagen/rsync over Tailscale SSH? work
+   entirely cloud-side?) is the biggest unanswered design question and is
+   deferred to `proposed`. The local tent bind-mounted `$PWD`; a cloud tent
+   cannot.
+2. **Ephemeral vs. reattachable.** Per-session throwaway droplets (clean, but
+   slow cold-start and repeated clone cost) vs. a long-lived per-operator tent
+   you reattach to. Likely a knob.
+3. **Cost / lifecycle hygiene.** Cloud tents cost money and leak if not
+   destroyed; `down` must be reliable and a sweep for orphaned droplets is
+   probably required.
+4. **Unbypassable-settings on a VM the operator controls.** FDR-0007's
+   invariant assumed clown controlled the container. On a cloud VM the operator
+   has root via the provider console — the threat model shifts from "contain
+   the agent on the user's trusted machine" to "isolate the agent's blast
+   radius onto a disposable machine." This needs to be restated explicitly.
+5. **Auth / credentials in-tent.** Claude OAuth credentials, signing keys, and
+   ssh-agent reaching a cloud VM is a different (and in some ways simpler, via
+   Tailscale SSH) problem than the local bind-mount + `ssh -R` bridge.
+
+## References
+
+- eng FDR-0005 — NixOS cloud tent image (DigitalOcean first)
+- clown RFC-0012 — clown↔eng cloud-tent provisioning contract
+- FDR-0007 — tent (superseded substrate: local container)
+- FDR-0012 — tent narrow userspace + hook tunnel (superseded: a response to the
+  local-container arch problem the cloud substrate removes)
+- FDR-0009 — `--naked` emergency bypass (the named escape; unchanged)
+- `friedenberg/ts-do-piho` — DO + Tailscale + OpenTofu prior art

--- a/docs/rfcs/0012-cloud-tent-provisioning.md
+++ b/docs/rfcs/0012-cloud-tent-provisioning.md
@@ -50,8 +50,10 @@ contain any tailnet identifier, auth key, or operator secret.
 
 1.3. The image MUST boot with: `services.tailscale` enabled, an SSH daemon
 reachable over the tailnet, a serial console (for provider-console recovery),
-and the agent runtime clown FDR-0014 requires (the latter referenced, not
-specified here).
+`git` plus the agent runtime clown FDR-0014 requires (the latter referenced,
+not specified here). The tent **clones its own repos** (FDR-0014); the image is
+the host of those clones, not a mirror of an operator's working tree, so no
+file-sync agent is part of this contract.
 
 ## 2. First-boot auth-key delivery
 
@@ -74,6 +76,15 @@ Tailscale credentials (`TAILSCALE_API_KEY` / OAuth client) supplied to the
 `tailscale` OpenTofu provider. "The current user's tailnet by default" is
 realized by *which credentials mint the key*, never by a tailnet id in the
 image (2.2 of FDR-0005).
+
+2.5. **Repo-clone credentials.** Since the tent clones its own repos (§1.3), a
+git credential (GitHub token / deploy key, or a forwarded ssh-agent over
+Tailscale SSH) is required for private clones and for pushing work back. Like
+the auth key (2.1), any such credential MUST NOT be baked into the image and
+MUST land only in guest tmpfs if delivered at provision time. The set of repos
+to clone is a provisioning input. The exact mechanism (auto-clone at first boot
+vs. operator-driven clone after Tailscale-SSH connect) is open (FDR-0014 open
+question 1) and is NOT yet a normative clause.
 
 ## 3. Network posture
 

--- a/docs/rfcs/0012-cloud-tent-provisioning.md
+++ b/docs/rfcs/0012-cloud-tent-provisioning.md
@@ -1,0 +1,144 @@
+---
+status: exploring
+date: 2026-06-09
+---
+
+# Cloud Tent Provisioning Contract (clown ↔ eng)
+
+## Abstract
+
+This specification defines the contract between the **image producer** (eng,
+FDR-0005) and the **orchestrator** (clown's `--tent` CLI, FDR-0014) for
+standing up a cloud-hosted tent: a NixOS VM that boots already joined to the
+operator's Tailscale tailnet. It fixes the interface — image format, the
+first-boot auth-key delivery path, the network/firewall posture, the hostname
+and tailnet conventions, and the OpenTofu input/output surface — so the two
+repos build, version, and ship independently. It deliberately does **not**
+specify how the image is built internally (eng FDR-0005) nor what agent
+workload runs inside the tent (clown FDR-0014).
+
+## Introduction
+
+clown FDR-0014 repoints tents from local containers to cloud VMs. The split of
+responsibility (decided 2026-06-09): **eng = image, clown = CLI.** eng emits a
+reproducible NixOS image per provider; clown drives provisioning via OpenTofu
+using the `digitalocean` and `tailscale` providers, following the
+`friedenberg/ts-do-piho` prior art. Two repos implementing one capability is
+exactly the case an RFC exists for (eng AGENTS.md: "RFC specifies the interface
+contract when multiple repos implement it").
+
+The contract must let a destroyed tent leave no tailnet residue, must never put
+the Tailscale auth key where it can be recovered (Nix store, image, git, tofu
+state-at-rest in plaintext), and must keep the guest reachable *only* over the
+tailnet.
+
+## Requirements Language
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as in RFC 2119.
+
+## 1. Image artifact
+
+1.1. eng MUST publish, per provider, a flake package producing an uploadable
+disk image:
+- DigitalOcean: `packages.x86_64-linux.tent-cloud-image-digitalocean`,
+  `nixos-generators` `format = "do"` (gzipped raw disk).
+- Hetzner (deferred): `…-hetzner`, a Hetzner-consumable format.
+
+1.2. The image MUST be reproducible from a pinned `flake.lock` and MUST NOT
+contain any tailnet identifier, auth key, or operator secret.
+
+1.3. The image MUST boot with: `services.tailscale` enabled, an SSH daemon
+reachable over the tailnet, a serial console (for provider-console recovery),
+and the agent runtime clown FDR-0014 requires (the latter referenced, not
+specified here).
+
+## 2. First-boot auth-key delivery
+
+2.1. The Tailscale auth key MUST be delivered to the guest at provision time
+through the provider's **user-data / metadata** channel, NOT baked into the
+image.
+
+2.2. The guest MUST land the key at a single well-known path, tmpfs-backed,
+mode 0600: **`/run/tailscale-authkey`**. `services.tailscale.authKeyFile`
+points there.
+
+2.3. The key MUST be **ephemeral**, **pre-authorized**, and **single-use**
+(`reusable = false`, `ephemeral = true`, `preauthorized = true` on the
+`tailscale_tailnet_key` resource). Ephemeral guarantees a destroyed tent
+self-evicts from the tailnet; single-use guarantees a leaked image cannot
+re-join.
+
+2.4. The key MUST be minted in the **operator's** tailnet, via the operator's
+Tailscale credentials (`TAILSCALE_API_KEY` / OAuth client) supplied to the
+`tailscale` OpenTofu provider. "The current user's tailnet by default" is
+realized by *which credentials mint the key*, never by a tailnet id in the
+image (2.2 of FDR-0005).
+
+## 3. Network posture
+
+3.1. The provisioner MUST attach a provider firewall that is **deny-all
+inbound except Tailscale**, mirroring ts-do-piho:
+- inbound UDP 41641 from `0.0.0.0/0, ::/0` (Tailscale WireGuard),
+- inbound UDP 3478 from `100.64.0.0/10` (STUN, tailnet CGNAT range),
+- outbound unrestricted (ICMP, TCP, UDP) so the node can reach DERP/the
+  control plane.
+
+3.2. There MUST be no inbound public SSH (port 22). Operator SSH access is
+over Tailscale (Tailscale SSH, `--ssh` in `extraUpFlags`).
+
+3.3. A short-lived bootstrap SSH key MAY be attached for the
+provider-`remote-exec`/user-data path before Tailscale is up (ts-do-piho mints
+a `tls_private_key` for exactly this), but it MUST NOT remain a standing public
+ingress after first boot.
+
+## 4. Hostname / identity convention
+
+4.1. The droplet name and the Tailscale hostname MUST share a deterministic,
+collision-resistant convention so the operator (and `clown --tent status`) can
+map a tailnet node back to a tent. Proposed: `tent-<short-session-or-rand>`;
+exact scheme TBD in `proposed`.
+
+4.2. `extraUpFlags` MUST set `--hostname` to that name so MagicDNS resolves the
+tent predictably.
+
+## 5. OpenTofu surface
+
+5.1. clown ships the HCL (provider config + droplet + firewall + tailnet key),
+adapted from ts-do-piho, and invokes `tofu` (Nix-pinned). The HCL MUST expose:
+- **inputs (variables)**: tent name, region/size (provider-specific, with
+  defaults), and the image reference (id or URL, per §6).
+- **outputs**: the tent's tailnet hostname/IP and the droplet id, which clown
+  reads back to connect and to destroy.
+
+5.2. tofu state contains the minted (single-use, ephemeral) key and MUST be
+encrypted at rest (git-secret today, matching ts-do-piho; sops/agenix is
+future work, eng#77). A destroyed tent's key is already useless (single-use +
+ephemeral), bounding the blast radius of a state leak.
+
+5.3. `clown --tent down` MUST run `tofu destroy` and SHOULD verify the tailnet
+node is gone (ephemeral expiry is the backstop).
+
+## 6. Image distribution (open)
+
+6.1. For DigitalOcean the image reference is either a custom-image-by-URL
+(image gzip hosted at a reachable URL, `doctl compute image create`) or an
+in-region snapshot. The contract requires only that the tofu `image` input
+accepts a stable id; which mechanism produces that id is resolved in the
+experimental phase (FDR-0005 open question 1).
+
+## 7. Versioning
+
+7.1. eng and clown version independently. A breaking change to any MUST clause
+in §§2–4 (the auth-key path, the firewall shape, the hostname flag) is a
+contract change requiring a bump to this RFC and coordinated releases. The
+image format (§1) and the tofu surface (§5) MAY evolve without an RFC bump as
+long as §§2–4 hold.
+
+## References
+
+- clown FDR-0014 — cloud tent (orchestrator side)
+- eng FDR-0005 — NixOS cloud tent image (producer side)
+- `friedenberg/ts-do-piho` — DO + Tailscale + OpenTofu prior art (HCL shapes
+  for the droplet, ephemeral tailnet key, and firewall reproduced here)
+- RFC 2119 — requirements language


### PR DESCRIPTION
Repoint tents from local containers (podman/lima) to cloud-hosted
NixOS VMs (DigitalOcean first, Hetzner later) that auto-join the
operator's tailnet. Design-first, per the agreed scope.

- FDR-0014: the pivot. Cloud VM substrate removes the cross-arch and
  one-VM-at-a-time problems FDR-0012/0007 fought; policy goal (bound
  the agent's blast radius) preserved. Splits eng=image, clown=CLI;
  OpenTofu drives provisioning (ts-do-piho prior art). Inventories the
  podman/lima surface to retire and marks it deprecated (kept building,
  removed in a named follow-up once FDR-0014 is accepted).
- RFC-0012: the clown<->eng provisioning contract — image format,
  /run/tailscale-authkey first-boot delivery, ephemeral single-use
  tailnet key minted in the operator's tailnet, deny-all-but-Tailscale
  firewall, hostname convention, OpenTofu input/output surface.
- FDR-0007 / FDR-0012: marked superseded-by FDR-0014.

https://claude.ai/code/session_01N68T8btoGUPhbUB2Siyhdc