### PR TITLE
feat(provider): headless `trapeze` provider (OpenRouter + XMPP)

### DIFF
--- a/cmd/clown/main.go
+++ b/cmd/clown/main.go
@@ -434,6 +434,8 @@ func runWithFlags(flags parsedFlags) int {
 		return runOpencode(cliPath, flags.forwarded, selectedProfile)
 	case "crush":
 		return runCrush(cliPath, flags.forwarded, selectedProfile)
+	case "trapeze":
+		return runTrapeze(cliPath, flags.forwarded, selectedProfile)
 	case "clownbox":
 		return runClownbox(cliPath, flags, prompts, pluginDirs)
 	default:
@@ -1379,6 +1381,14 @@ func resolveProvider(name string) (string, error) {
 		return buildcfg.OpencodeCliPath, nil
 	case "crush":
 		return buildcfg.CrushCliPath, nil
+	case "trapeze":
+		// Headless trapeze provider (OpenRouter backend + XMPP frontend). The
+		// binary path is burned in by nix builds; a plain `go build` leaves it
+		// empty, so fall back to resolving "trapeze" on PATH for dev.
+		if buildcfg.TrapezeCliPath == "" {
+			return "trapeze", nil
+		}
+		return buildcfg.TrapezeCliPath, nil
 	case "clownbox":
 		if buildcfg.ClownboxCliPath == "" {
 			return "", fmt.Errorf("%s", clownboxDisabledMessage)
@@ -1441,7 +1451,7 @@ func printHelp() {
 	fmt.Printf(`Usage: clown [clown-flags] -- [provider-args]
 
 Clown flags (must appear before --):
-  --provider <name>          Provider to use: claude, codex, circus, opencode (default: %s)
+  --provider <name>          Provider to use: claude, codex, circus, opencode, crush, trapeze (default: %s)
   --profile <name>           Profile name; implies --provider from profile config%s
   --naked                    Pass through to provider without clown wrapping
   --skip-failed              Continue if plugin servers fail to start

--- a/cmd/clown/trapeze.go
+++ b/cmd/clown/trapeze.go
@@ -1,0 +1,134 @@
+package main
+
+// Trapeze provider dispatch — the headless XMPP agent (prototype 2).
+//
+// Unlike the other providers, `--provider trapeze` runs no TUI: it execs
+// `trapeze xmpp-agent`, which logs in to XMPP as a 1:1 chat bot and answers
+// each direct message with an OpenRouter chat completion (pure conversational,
+// no tools). clown is deliberately THIN here — it resolves the OpenRouter
+// credentials and exports them, then forwards everything else straight through:
+//
+//	clown --provider trapeze -- \
+//	  --jid agent@krone --server krone:5222 --insecure --model openai/gpt-4o-mini
+//
+// Credential resolution (highest precedence first):
+//  1. a named --profile (its url/token/model),
+//  2. ~/.config/circus/openrouter.toml (url/token/model — same shape as
+//     opencode.toml / crush.toml),
+//  3. the inherited OPENROUTER_* environment (clown sets nothing; trapeze reads
+//     it directly).
+//
+// The XMPP connection flags (--jid/--password/--server/--insecure) and the
+// model/system-prompt flags are trapeze's own; clown passes them through after
+// `--`. trapeze also honours TRAPEZE_XMPP_PASSWORD / OPENROUTER_* from the env.
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/amarbel-llc/clown/internal/profile"
+)
+
+// openRouterConfig is the resolved OpenRouter backend for the trapeze provider.
+type openRouterConfig struct {
+	URL   string
+	Token string
+	Model string
+}
+
+// openRouterConfigPath returns ~/.config/circus/openrouter.toml.
+func openRouterConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "circus", "openrouter.toml"), nil
+}
+
+// readOpenRouterConfig parses url/token/model from openrouter.toml. A missing
+// file is NOT an error (returns the zero config) — the env fallback covers it.
+func readOpenRouterConfig() (openRouterConfig, error) {
+	path, err := openRouterConfigPath()
+	if err != nil {
+		return openRouterConfig{}, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return openRouterConfig{}, nil
+		}
+		return openRouterConfig{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var cfg openRouterConfig
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.Trim(strings.TrimSpace(v), `"`)
+		switch k {
+		case "url":
+			cfg.URL = v
+		case "token":
+			cfg.Token = v
+		case "model":
+			cfg.Model = v
+		}
+	}
+	return cfg, scanner.Err()
+}
+
+// resolveOpenRouter picks the OpenRouter backend per the precedence above.
+func resolveOpenRouter(prof *profile.Profile) (openRouterConfig, error) {
+	if prof != nil && prof.Token != "" {
+		return openRouterConfig{URL: prof.URL, Token: prof.Token, Model: prof.Model}, nil
+	}
+	return readOpenRouterConfig()
+}
+
+func runTrapeze(trapezePath string, args []string, prof *profile.Profile) int {
+	cfg, err := resolveOpenRouter(prof)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clown: trapeze: %v\n", err)
+		return 1
+	}
+
+	cmd := exec.Command(trapezePath, append([]string{"xmpp-agent"}, args...)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Overlay resolved creds onto the inherited env; leave unset fields to the
+	// environment (trapeze reads OPENROUTER_*/TRAPEZE_XMPP_PASSWORD itself).
+	env := os.Environ()
+	if cfg.Token != "" {
+		env = append(env, "OPENROUTER_API_KEY="+cfg.Token)
+	}
+	if cfg.URL != "" {
+		env = append(env, "OPENROUTER_BASE_URL="+cfg.URL)
+	}
+	if cfg.Model != "" {
+		env = append(env, "OPENROUTER_MODEL="+cfg.Model)
+	}
+	cmd.Env = env
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "clown: trapeze: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/clown/trapeze_test.go
+++ b/cmd/clown/trapeze_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/amarbel-llc/clown/internal/profile"
+)
+
+func TestReadOpenRouterConfigMissingFileIsZero(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg, err := readOpenRouterConfig()
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if cfg != (openRouterConfig{}) {
+		t.Errorf("expected zero config, got %+v", cfg)
+	}
+}
+
+func TestReadOpenRouterConfigParse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "circus")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	contents := "# openrouter\nurl = \"https://openrouter.ai/api/v1\"\ntoken = \"sk-or-xyz\"\nmodel = \"openai/gpt-4o-mini\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "openrouter.toml"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := readOpenRouterConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.URL != "https://openrouter.ai/api/v1" || cfg.Token != "sk-or-xyz" || cfg.Model != "openai/gpt-4o-mini" {
+		t.Errorf("unexpected parse: %+v", cfg)
+	}
+}
+
+func TestResolveOpenRouterProfileWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "circus")
+	_ = os.MkdirAll(dir, 0o700)
+	_ = os.WriteFile(filepath.Join(dir, "openrouter.toml"), []byte("token=\"from-file\"\n"), 0o600)
+
+	prof := &profile.Profile{URL: "https://gw/v1", Token: "from-profile", Model: "m"}
+	cfg, err := resolveOpenRouter(prof)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Token != "from-profile" {
+		t.Errorf("profile token should win, got %q", cfg.Token)
+	}
+}

--- a/internal/buildcfg/buildcfg.go
+++ b/internal/buildcfg/buildcfg.go
@@ -1,12 +1,16 @@
 package buildcfg
 
 var (
-	ClaudeCliPath       string
-	CodexCliPath        string
-	CircusCliPath       string
-	OpencodeCliPath     string
-	CrushCliPath        string
-	ClownboxCliPath     string
+	ClaudeCliPath   string
+	CodexCliPath    string
+	CircusCliPath   string
+	OpencodeCliPath string
+	CrushCliPath    string
+	ClownboxCliPath string
+	// TrapezeCliPath is the absolute path to the trapeze binary, baked in for
+	// the headless `trapeze` provider (OpenRouter backend + XMPP frontend).
+	// Empty (the default `go build`) falls back to resolving "trapeze" on PATH.
+	TrapezeCliPath      string
 	AgentsFile          string
 	DisallowedToolsFile string
 	SystemPromptAppendD string
@@ -14,8 +18,8 @@ var (
 	// lowest-precedence layer of the clownfile cascade, supplying default [attach]
 	// multiplexer self-wrap templates. Empty in dev builds (then skipped).
 	DefaultClownfilePath string
-	Version             string
-	Commit              string
+	Version              string
+	Commit               string
 	// ShortSha is the abbreviated git revision (git's short rev, with a
 	// "-dirty" suffix for dirty trees). Displayed alongside Version as the
 	// `<version>+<shortSha>` build identifier the agent stamps into


### PR DESCRIPTION
Adds `clown --provider trapeze`: a headless provider that execs `trapeze xmpp-agent`, a 1:1 XMPP chat bot backed by OpenRouter (pure conversational). Prototype 2 of the XMPP messaging work — clown stays thin and reuses its existing wrap-an-agent model (like crush/opencode).

## Changes
- `resolveProvider`: `trapeze` case — `buildcfg.TrapezeCliPath`, falling back to resolving `trapeze` on `PATH` for dev builds — plus the dispatch case.
- `cmd/clown/trapeze.go` — `runTrapeze` resolves the OpenRouter backend by precedence (named `--profile` → `~/.config/circus/openrouter.toml` (`url`/`token`/`model`, same shape as opencode/crush gateway configs) → inherited `OPENROUTER_*` env), overlays the resolved creds onto the child env, and runs `trapeze xmpp-agent <forwarded args>`. XMPP connection flags pass straight through.
- `buildcfg.TrapezeCliPath`; `--provider` usage text updated.
- Tests for `openrouter.toml` parsing (missing-file-is-zero, field parse) + profile-wins precedence.

## Usage
```sh
export OPENROUTER_API_KEY=sk-or-...
clown --provider trapeze -- \
  --jid agent@krone --server krone:5222 --insecure --model openai/gpt-4o-mini
```

## Verification
`go build ./...` and the new provider tests pass. nix-build wiring of `buildcfg.TrapezeCliPath` (an ldflag + trapeze flake input) is a documented follow-up; dev builds resolve `trapeze` from `PATH`.

## Related
- `amarbel-llc/trapeze` — the `trapeze xmpp-agent` harness this provider launches
- `amarbel-llc/circus` — `docs/reference/headless-xmpp-openrouter-agent.md` + dev harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5aBpoX43KwauCMRMR5UPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5aBpoX43KwauCMRMR5UPR)_